### PR TITLE
add context and gamma ver

### DIFF
--- a/src/cslc_utils.py
+++ b/src/cslc_utils.py
@@ -6,12 +6,19 @@ import fsspec
 import matplotlib.pyplot as plt
 import folium
 
-def read_cslc(h5file):
+def read_cslc(h5file, version='calval'):
     # Load the CSLC and necessary metadata
-    grid_path = f'data'
-    metadata_path = f'metadata'
-    burstmetadata_path = f'metadata/processing_information/input_burst_metadata'
-    id_path = f'identification'
+    if version == 'gamma':
+        DATA_ROOT = 'science/SENTINEL1'
+        grid_path = f'{DATA_ROOT}/CSLC/grids'
+        metadata_path = f'{DATA_ROOT}/CSLC/metadata'
+        burstmetadata_path = f'{DATA_ROOT}/CSLC/metadata/processing_information/s1_burst_metadata'
+        id_path = f'{DATA_ROOT}/identification'
+    else:
+        grid_path = f'data'
+        metadata_path = f'metadata'
+        burstmetadata_path = f'metadata/processing_information/input_burst_metadata'
+        id_path = f'identification'
 
     if h5file[:2] == 's3':
         print(f'Streaming: {h5file}')  
@@ -25,12 +32,19 @@ def read_cslc(h5file):
         
     return cslc
 
-def cslc_info(h5file):
+def cslc_info(h5file, version='calval'):
     # Load the CSLC and necessary metadata
-    grid_path = f'data'
-    metadata_path = f'metadata'
-    burstmetadata_path = f'metadata/processing_information/input_burst_metadata'
-    id_path = f'identification'
+    if version == 'gamma':
+        DATA_ROOT = 'science/SENTINEL1'
+        grid_path = f'{DATA_ROOT}/CSLC/grids'
+        metadata_path = f'{DATA_ROOT}/CSLC/metadata'
+        burstmetadata_path = f'{DATA_ROOT}/CSLC/metadata/processing_information/s1_burst_metadata'
+        id_path = f'{DATA_ROOT}/identification'  
+    else:
+        grid_path = f'data'
+        metadata_path = f'metadata'
+        burstmetadata_path = f'metadata/processing_information/input_burst_metadata'
+        id_path = f'identification'
 
     if h5file[:2] == 's3':
         s3f = fsspec.open(h5file, mode='rb', anon=True, default_fill_cache=False)


### PR DESCRIPTION
I updated the CSLC streaming nb to include context for users. I also included the option to choose near-calval version or gamma version. The way I read in the gamma products from S3 is very very slow at the moment. I tried to write some code that doesn't require the whole path hardwired. I think using * is what is slowing things down. Happy to implement any improvements.