### PR TITLE
Update packages in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - bokeh=2.4.3
   - boto3
-  - gdal=3.2.2
+  - gdal>=3.6.2
   - geopandas=0.10.2
   - geoviews=1.9.5
   - geoviews-core=1.9.5
@@ -23,18 +23,21 @@ dependencies:
   - numpy=1.21.6
   - panel=0.13.1
   - pip
-  - python=3.7
+  - python>=3.10
   - requests
-  - rasterio=1.2.6
+  - rasterio>=1.2.6
   - rioxarray
-  - s3fs
+  - s3fs>=2021.8.0
   - xarray=0.20.2
   - pip:
     - folium
     - gdal-utils
+    - ipyleaflet
     - jupyterlab==3.4.3
     - jupyterlab-server==2.14.0
+    - leafmap
+    - localtileserver
     - lxml
-    - pystac-client
+    - pystac-client==0.5.1
     - scikit-image
     - selenium

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: opera_app
+name: opera_app_testing
 channels:
   - conda-forge
   - defaults
@@ -9,13 +9,20 @@ dependencies:
   - geopandas=0.10.2
   - geoviews=1.9.5
   - geoviews-core=1.9.5
+  - folium
   - fsspec
   - h5py
   - holoviews=1.14.9
   - hvplot=0.8.0
   - ipykernel=6.15.0
+  - ipyleaflet
   - ipython
   - ipympl
+  - jupyterlab==3.4.3
+  - jupyterlab_server==2.14.0
+  - leafmap
+  - localtileserver
+  - lxml
   - matplotlib
   - nodejs=14.18.3
   - notebook=6.4.12
@@ -23,21 +30,14 @@ dependencies:
   - numpy=1.21.6
   - panel=0.13.1
   - pip
+  - pystac-client==0.5.1
   - python>=3.10
   - requests
   - rasterio>=1.2.6
   - rioxarray
+  - scikit-image
+  - selenium
   - s3fs>=2021.8.0
   - xarray=0.20.2
   - pip:
-    - folium
     - gdal-utils
-    - ipyleaflet
-    - jupyterlab==3.4.3
-    - jupyterlab-server==2.14.0
-    - leafmap
-    - localtileserver
-    - lxml
-    - pystac-client==0.5.1
-    - scikit-image
-    - selenium

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: opera_app_testing
+name: opera_app
 channels:
   - conda-forge
   - defaults

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - h5py
   - holoviews=1.14.9
   - hvplot=0.8.0
+  - imageio=2.31.1
   - ipykernel=6.15.0
   - ipyleaflet
   - ipython


### PR DESCRIPTION
This PR includes updates to the versions of several dependencies in `environment.yml`. Key updates are to GDAL>=3.6.2 and Python>=3.10, which should solve the issues posed in #26 and #27. These changes required updates to several other package versions, and new libraries `leafmap` and `ipyleaflet` have been added to the environment. Additionally, packages have been migrated to Conda install from pip, with the exception of `gdal-utils` which is only pip installable.

Updated environment has been tested across all notebooks in OPERA_Applications repo successfully. However, additional testing would be helpful to ensure all workflows remain functional.
