### PR TITLE
CSLC: use scipy for computing coherence

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -38,6 +38,7 @@ dependencies:
   - rasterio>=1.2.6
   - rioxarray
   - scikit-image
+  - scipy
   - selenium
   - s3fs>=2021.8.0
   - xarray=0.20.2


### PR DESCRIPTION
Just stumbled across this. Using `scipy.ndimage.uniform_filter` should be more performant than the custom function `cslc_utils.moving_window_mean`. The results are nearly identical.