### PR TITLE
Update short_name for DSWx-HLS product

### DIFF
--- a/leafmap/OPERA_Leafmap_Access_and_Viz.ipynb
+++ b/leafmap/OPERA_Leafmap_Access_and_Viz.ipynb
@@ -204,7 +204,7 @@
    "outputs": [],
    "source": [
     "dswx_results, dswx_gdf = leafmap.nasa_data_search(\n",
-    "    short_name='OPERA_L3_DSWX-HLS',\n",
+    "    short_name='OPERA_L3_DSWX-HLS_V1',\n",
     "    cloud_hosted=True,\n",
     "    bounding_box= AOI,\n",
     "    temporal=(\"2023-10-01\", str(datetime.now().date())),\n",


### PR DESCRIPTION
This is necessary given the change in the expected DSWx-HLS shortname upstream from 'OPERA_L3_DSWX-HLS' to 'OPERA_L3_DSWX-HLS_V1'.

Otherwise, the program would error out when querying for products with the invalid shortname 'OPERA_L3_DSWX-HLS'