### PR TITLE
Remove defaults channel from environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: opera_app
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - bokeh=2.4.3
   - boto3


### PR DESCRIPTION
Removes the 'defaults' channel from the environment.yml to ensure dependency downloads occur from conda-forge only